### PR TITLE
refactor: Rider→Order 연동에서 WebClient 사용 중단
- OrderClient/의존성 제거
- RiderDeliveryService에서 Order 상태 JPA로 직접 갱신(단일 트랜잭션)
- 관련 보안/설정 정리

### DIFF
--- a/backend/src/main/java/io/goorm/team02/core/deliveries/domain/Delivery.java
+++ b/backend/src/main/java/io/goorm/team02/core/deliveries/domain/Delivery.java
@@ -61,4 +61,8 @@ public class Delivery extends BaseEntity {
 
     // 필요하면 requestedAt도 게터만 유지
     private LocalDateTime requestedAt = LocalDateTime.now();
+
+    public void assignRider(User rider) {
+        this.rider = rider;
+    }
 }

--- a/backend/src/main/java/io/goorm/team02/core/deliveries/service/RiderDeliveryService.java
+++ b/backend/src/main/java/io/goorm/team02/core/deliveries/service/RiderDeliveryService.java
@@ -4,11 +4,15 @@ package io.goorm.team02.core.deliveries.service;
 import io.goorm.team02.core.deliveries.domain.Delivery;
 import io.goorm.team02.core.deliveries.domain.enums.DeliveryStatus;
 import io.goorm.team02.core.deliveries.repository.DeliveryRepository;
+import io.goorm.team02.core.users.domain.User;
+import io.goorm.team02.core.users.repository.UserAddressRepository;
+import io.goorm.team02.core.users.repository.UserinfoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 // RiderDeliveryService.java
 @Service
@@ -16,17 +20,29 @@ import java.time.LocalDateTime;
 @Transactional
 public class RiderDeliveryService {
     private final DeliveryRepository repo;
+    private final UserinfoRepository userInfoRepository;
 
     private Delivery get(Long id){ return repo.findById(id).orElseThrow(); }
 
-    public Delivery accept(Long id, String riderId){
-        var d = get(id);
-        if (d.getStatus()!=DeliveryStatus.REQUESTED) throw new IllegalStateException("not REQUESTED");
+    @Transactional
+    public Delivery accept(Long id, String riderIdStr){
+        Delivery d = get(id);
+        if (d.getStatus() != DeliveryStatus.REQUESTED)
+            throw new IllegalStateException("not REQUESTED");
+
+        Long riderId;
+        try { riderId = Long.valueOf(riderIdStr); }
+        catch (NumberFormatException e) { throw new IllegalArgumentException("invalid riderId: " + riderIdStr); }
+
+        User rider = userInfoRepository.findById(riderId)
+                .orElseThrow(() -> new IllegalArgumentException("rider not found: " + riderId));
+
+        d.assignRider(rider);                 // 또는 d.setRider(rider)
         d.setStatus(DeliveryStatus.ACCEPTED);
-        // d.setRider(...); // riderId 매핑 필요 시
         d.setAcceptedAt(LocalDateTime.now());
-        return d;
+        return d;                             // 영속 상태면 save 불필요
     }
+
 
     public Delivery reject(Long id, String riderId, String reason){
         var d = get(id);

--- a/backend/src/main/java/io/goorm/team02/core/deliveries/service/RiderDeliveryService.java
+++ b/backend/src/main/java/io/goorm/team02/core/deliveries/service/RiderDeliveryService.java
@@ -4,8 +4,9 @@ package io.goorm.team02.core.deliveries.service;
 import io.goorm.team02.core.deliveries.domain.Delivery;
 import io.goorm.team02.core.deliveries.domain.enums.DeliveryStatus;
 import io.goorm.team02.core.deliveries.repository.DeliveryRepository;
+import io.goorm.team02.core.orders.domain.Order;
+import io.goorm.team02.core.orders.domain.enums.OrderStatus;
 import io.goorm.team02.core.users.domain.User;
-import io.goorm.team02.core.users.repository.UserAddressRepository;
 import io.goorm.team02.core.users.repository.UserinfoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,7 +22,6 @@ import java.util.Optional;
 public class RiderDeliveryService {
     private final DeliveryRepository repo;
     private final UserinfoRepository userInfoRepository;
-
     private Delivery get(Long id){ return repo.findById(id).orElseThrow(); }
 
     @Transactional
@@ -37,9 +37,12 @@ public class RiderDeliveryService {
         User rider = userInfoRepository.findById(riderId)
                 .orElseThrow(() -> new IllegalArgumentException("rider not found: " + riderId));
 
+        d.getOrder().setStatus(OrderStatus.ACCEPTED);
         d.assignRider(rider);                 // 또는 d.setRider(rider)
         d.setStatus(DeliveryStatus.ACCEPTED);
         d.setAcceptedAt(LocalDateTime.now());
+
+
         return d;                             // 영속 상태면 save 불필요
     }
 
@@ -48,6 +51,7 @@ public class RiderDeliveryService {
         var d = get(id);
         if (d.getStatus()!=DeliveryStatus.REQUESTED) throw new IllegalStateException("not REQUESTED");
         d.setStatus(DeliveryStatus.CANCELLED);
+        d.getOrder().setStatus(OrderStatus.CANCELLED);
         return d;
     }
 
@@ -55,6 +59,7 @@ public class RiderDeliveryService {
         var d = get(id);
         if (d.getStatus()!=DeliveryStatus.ACCEPTED) throw new IllegalStateException("not ACCEPTED");
         d.setStatus(DeliveryStatus.PICKED_UP);
+        d.getOrder().setStatus(OrderStatus.PICKED_UP);
         d.setPickedUpAt(LocalDateTime.now());
         return d;
     }
@@ -64,6 +69,7 @@ public class RiderDeliveryService {
         if (d.getStatus()!=DeliveryStatus.PICKED_UP) throw new IllegalStateException("not PICKED_UP");
         d.setStatus(DeliveryStatus.DELIVERED);
         d.setDeliveredAt(LocalDateTime.now());
+        d.getOrder().setStatus(OrderStatus.DELIVERED);
         return d;
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -47,3 +47,11 @@ spring:
 app:
   s3:
     folder: store
+
+
+
+# Rider 서비스에서 Order 서비스 API 호출용 베이스 URL
+# - 기본값은 로컬 실행 시 http://localhost:8080
+# - 환경별로 ORDER_SERVICE_URL 환경변수로 덮어써서 사용
+order-service:
+  url: ${ORDER_SERVICE_URL:http://localhost:8080}

--- a/frontend/src/pages/driver/DriverMain.vue
+++ b/frontend/src/pages/driver/DriverMain.vue
@@ -89,7 +89,8 @@ export default {
 
       const resp = await fetch(`${API_BASE}/api/rider/deliveries/${id}/pickup`, {
         method: 'PUT',
-        headers: { Authorization: `Bearer ${token}`},
+        headers: { Authorization: `Bearer ${token}` },
+
       });
       if (!resp.ok) throw new Error(`픽업 실패 ${resp.status}`);
     },
@@ -177,36 +178,30 @@ export default {
     async fetchDeliveries() {
       try {
         const token = localStorage.getItem('jwt');
-        const res = await fetch(`${API_BASE}/api/rider/deliveries`, {
-          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        const res = await fetch(`${API_BASE}/api/orders/delivery/available`, {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${token}` },
         });
         const json = await res.json();
+        // 1) json이 배열이면 그대로 사용
+        const items = Array.isArray(json) ? json : (json?.data ?? []);
+        // 2) OrderResponse 스키마에 맞게 매핑
+        const mapped = items.map((o, idx) => ({
+          _key: `ord:${o.id}|${o.orderNumber}|${idx}`,
+          id: o.id,
+          status: o.status,
+          restaurantName: o.storeName,
+          customerAddress: [o.deliveryAddress, o.deliveryDetailAddress].filter(Boolean).join(' '),
+          orderTime: o.orderedAt ?? o.cookingCompletedAt ?? '-',
+          deliveryFee: o.deliveryFee ?? 0,
+          items: (o.orderItems ?? []).map(i => ({
+            name: i.menuName, quantity: i.quantity, price: i.totalPrice,
+          })),
+          total: o.totalAmount ?? 0,
+        }));
+        console.log('mapped len', mapped.length, mapped[0]);
 
-        // 여기부터 ↓↓↓
-        const items = json?.data?.items ?? json?.data ?? [];
-
-        const mapped = items.map((d, idx) => {
-          const id = d.deliveryId ?? d.id ?? `temp-${idx}`;
-          const key = `ord:${id}|${d.requestedAt ?? idx}|${d.pickupAddress ?? ''}|${d.deliveryAddress ?? ''}`;
-          return {
-            _key: key,                // 렌더용 고유키
-            id,                       // 로직용 ID
-            status: d.status,         // REQUESTED 여부 확인
-            riderId: d.riderId,
-            restaurantName: d.restaurantName || '가게',
-            restaurantAddress: d.pickupAddress,
-            customerAddress: d.deliveryAddress,
-            orderTime: d.requestedAt ? new Date(d.requestedAt).toLocaleString() : '-',
-            estimatedDeliveryTime: d.estimatedTime ? `${d.estimatedTime}분` : '미정',
-            distance: d.distanceKm ? `${d.distanceKm}km` : '-',
-            deliveryFee: d.fee ?? 0,
-            items: d.items ?? [],
-            total: d.totalPrice ?? 0,
-          };
-        });
-
-        // REQUESTED 상태만 노출
-        this.availableOrders = mapped.filter(o => o.status === 'REQUESTED');
+        this.availableOrders = mapped; // 필터·재할당 없음
 
         // 디버그 로그
         console.log('[final ids]', this.availableOrders.map(o => o.id), 'len=', this.availableOrders.length);

--- a/frontend/src/pages/driver/DriverMain.vue
+++ b/frontend/src/pages/driver/DriverMain.vue
@@ -85,12 +85,11 @@ export default {
       if (!id) throw new Error('currentOrder.id 없음');
 
       const token = localStorage.getItem('jwt');
-      const riderId = this.riderId || JSON.parse(localStorage.getItem('rider') || '{}').riderId;
+      const riderId = localStorage.getItem('userId'); // DB users.id 값
 
       const resp = await fetch(`${API_BASE}/api/rider/deliveries/${id}/pickup`, {
         method: 'PUT',
-        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ riderId }),
+        headers: { Authorization: `Bearer ${token}`},
       });
       if (!resp.ok) throw new Error(`픽업 실패 ${resp.status}`);
     },
@@ -130,7 +129,7 @@ export default {
       this.isAccepting = true;
       try {
         const token = localStorage.getItem('jwt');
-        const riderId = this.riderId || JSON.parse(localStorage.getItem('rider') || '{}').riderId;
+        const riderId = localStorage.getItem('userId'); // DB users.id 값
 
         const resp = await fetch(`${API_BASE}/api/rider/deliveries/${deliveryId}/accept`, {
           method: 'POST',


### PR DESCRIPTION
- **feat: 주문 수락 → 픽업 → 완료 플로우 구현, rider_id null 저장 문제 해결**
- **revert: WebClient 오케스트레이션 제거, 동일 DB JPA 갱신으로 회귀**
